### PR TITLE
Soft removal of the service keys documentation.

### DIFF
--- a/pages/configure-service-broker.md
+++ b/pages/configure-service-broker.md
@@ -23,7 +23,7 @@
 # Basic Configuration
 Within the following sections the documentation covers the maximum number of possibilities in regard of Service Broker configuration for the evoila OSB Framework. Each configuration section, which is not mandatory, is marked with (Optional).
 
-In the `spring` section we define the endpoint properties, for communication between Config Server, Service Key Manager, Backup Manager and Service Broker (RabbitMQ) and the storage backend which is based on MongoDB. In regard to the storage backend it is important to note, that MongoDB might be replaced with any database of choice. The only thing that needs to adapted are the interfaces in the `osb-persistence` module.
+In the `spring` section we define the endpoint properties, for communication between Config Server, Backup Manager and Service Broker (RabbitMQ) and the storage backend which is based on MongoDB. In regard to the storage backend it is important to note, that MongoDB might be replaced with any database of choice. The only thing that needs to adapted are the interfaces in the `osb-persistence` module.
 
 *Note: an important note here is, that we correlate multi site deployments with spring profiles. Means, the profiles section contains the name of the site, where the Service Broker is deployed.*
 
@@ -47,7 +47,7 @@ spring:
     cache: true
     mode: LEGACYHTML5
 ```
-The basic configuration for communication with the backend database, RabbitMQ (Config Updates, Service Key Creation) and Thymeleaf for Service Broker dashboard delivery. 
+The basic configuration for communication with the backend database, RabbitMQ (Config Updates) and Thymeleaf for Service Broker dashboard delivery. 
 
 ```yaml
 login:
@@ -446,15 +446,6 @@ endpoints:
     url: https://osb-autoscaler-core.cf.dev.eu-de-central.msh.host
   default: https://osb-couchdb.cf.dev.eu-de-central.msh.host
 ```
-
-**(Optional):** Service Key Manager 
-```yaml
-haproxy:
-  auth:
-    token: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  uri: https://osb-service-key-manager.cf.dev.eu-de-central.msh.host/agents/5b07c382ab86f100075e1292/schemas?type=listen
-```
-The Service Key Manager is described in detail in a later section. It enables Service Brokers to support the Service Key functionality of Cloud Foundry
 
 **(Optional):** Site Configuration 
 ```yaml

--- a/pages/configure-service-broker.md
+++ b/pages/configure-service-broker.md
@@ -23,7 +23,7 @@
 # Basic Configuration
 Within the following sections the documentation covers the maximum number of possibilities in regard of Service Broker configuration for the evoila OSB Framework. Each configuration section, which is not mandatory, is marked with (Optional).
 
-In the `spring` section we define the endpoint properties, for communication between Config Server, Backup Manager and Service Broker (RabbitMQ) and the storage backend which is based on MongoDB. In regard to the storage backend it is important to note, that MongoDB might be replaced with any database of choice. The only thing that needs to adapted are the interfaces in the `osb-persistence` module.
+In the `spring` section we define the endpoint properties, for communication between Config Server, Service Key Manager, Backup Manager and Service Broker (RabbitMQ) and the storage backend which is based on MongoDB. In regard to the storage backend it is important to note, that MongoDB might be replaced with any database of choice. The only thing that needs to adapted are the interfaces in the `osb-persistence` module.
 
 *Note: an important note here is, that we correlate multi site deployments with spring profiles. Means, the profiles section contains the name of the site, where the Service Broker is deployed.*
 
@@ -47,7 +47,7 @@ spring:
     cache: true
     mode: LEGACYHTML5
 ```
-The basic configuration for communication with the backend database, RabbitMQ (Config Updates) and Thymeleaf for Service Broker dashboard delivery. 
+The basic configuration for communication with the backend database, RabbitMQ (Config Updates, Service Key Creation) and Thymeleaf for Service Broker dashboard delivery. 
 
 ```yaml
 login:
@@ -446,6 +446,15 @@ endpoints:
     url: https://osb-autoscaler-core.cf.dev.eu-de-central.msh.host
   default: https://osb-couchdb.cf.dev.eu-de-central.msh.host
 ```
+
+**(Optional):** Service Key Manager 
+```yaml
+haproxy:
+  auth:
+    token: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  uri: https://osb-service-key-manager.cf.dev.eu-de-central.msh.host/agents/5b07c382ab86f100075e1292/schemas?type=listen
+```
+The Service Key Manager is described in detail in a later section. It enables Service Brokers to support the Service Key functionality of Cloud Foundry
 
 **(Optional):** Site Configuration 
 ```yaml

--- a/pages/configure-service-broker.md
+++ b/pages/configure-service-broker.md
@@ -447,14 +447,22 @@ endpoints:
   default: https://osb-couchdb.cf.dev.eu-de-central.msh.host
 ```
 
-**(Optional):** Service Key Manager 
+**(Optional):** Enabling Service Keys
+To enable the handling and creation of Service Keys in the Service Broker, add and set the following property to `true` in your configuration.
 ```yaml
-haproxy:
-  auth:
-    token: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  uri: https://osb-service-key-manager.cf.dev.eu-de-central.msh.host/agents/5b07c382ab86f100075e1292/schemas?type=listen
+service-keys:
+    enabled: true
 ```
-The Service Key Manager is described in detail in a later section. It enables Service Brokers to support the Service Key functionality of Cloud Foundry
+
+*Note: To enable Service Keys via Service Broker Dashboard in UI see Dashboard section and configure `serviceKeys: true` in the module definition.*
+
+```js
+sharedModules: {
+  general: true,
+  backup: false,
+  serviceKeys: true // This needs to be set to true
+}
+```
 
 **(Optional):** Site Configuration 
 ```yaml

--- a/pages/service-keys.md
+++ b/pages/service-keys.md
@@ -12,38 +12,7 @@
 ---
 
 # Service Keys
-Service Keys is a functionality introduced by Cloud Foundry, which enables users to create credentials, which are not bound to an specific application but instead used to connect to a Servce Instance from the outside. A Service Key can be created in Cloud Foundry via `cf create-service-key serviceInstanceName`. 
-
-Offering this functionality makes sense, when you have Services like database, where user might want to access the database with a fat client to analyse problems. To offer this functionality in your Service Broker add a class named `HaProxyServiceImpl` to: `de.evoila.cf.broker.haproxy`, with the following contents:
-
-```java
-@Service
-@ConditionalOnBean(HAProxyConfiguration.class)
-public class HAProxyServiceImpl extends HAProxyService {
-
-	@Override
-	public Mode getMode(ServerAddress serverAddress) {
-		return Mode.TCP;
-	}
-	
-	@Override
-	public List<String> getOptions(ServerAddress serverAddress) {
-		return new ArrayList<>();
-	}
-}
-```
-
-Having defined this class, the Service Key functionality should be autowired and configured automatically. It reuses the `bind-service` functionality of the Service Broker to create Service Keys.
-
-*Note: to enable Service Keys via Service Broker Dashboard in UI see Dashboard section and configure `serviceKeys: true` in the module definition.*
-
-```js
-sharedModules: {
-  general: true,
-  backup: false,
-  serviceKeys: true // This needs to be set to truw
-}
-```
+Service Keys are no longer supported by the evoila open service brokers.
 
 ---
 

--- a/pages/service-keys.md
+++ b/pages/service-keys.md
@@ -12,7 +12,38 @@
 ---
 
 # Service Keys
-Service Keys are no longer supported by the evoila open service brokers.
+Service Keys is a functionality introduced by Cloud Foundry, which enables users to create credentials, which are not bound to an specific application but instead used to connect to a Servce Instance from the outside. A Service Key can be created in Cloud Foundry via `cf create-service-key serviceInstanceName`. 
+
+Offering this functionality makes sense, when you have Services like database, where user might want to access the database with a fat client to analyse problems. To offer this functionality in your Service Broker add a class named `HaProxyServiceImpl` to: `de.evoila.cf.broker.haproxy`, with the following contents:
+
+```java
+@Service
+@ConditionalOnBean(HAProxyConfiguration.class)
+public class HAProxyServiceImpl extends HAProxyService {
+
+	@Override
+	public Mode getMode(ServerAddress serverAddress) {
+		return Mode.TCP;
+	}
+	
+	@Override
+	public List<String> getOptions(ServerAddress serverAddress) {
+		return new ArrayList<>();
+	}
+}
+```
+
+Having defined this class, the Service Key functionality should be autowired and configured automatically. It reuses the `bind-service` functionality of the Service Broker to create Service Keys.
+
+*Note: to enable Service Keys via Service Broker Dashboard in UI see Dashboard section and configure `serviceKeys: true` in the module definition.*
+
+```js
+sharedModules: {
+  general: true,
+  backup: false,
+  serviceKeys: true // This needs to be set to truw
+}
+```
 
 
 ---

--- a/pages/service-keys.md
+++ b/pages/service-keys.md
@@ -14,37 +14,11 @@
 # Service Keys
 Service Keys is a functionality introduced by Cloud Foundry, which enables users to create credentials, which are not bound to an specific application but instead used to connect to a Servce Instance from the outside. A Service Key can be created in Cloud Foundry via `cf create-service-key serviceInstanceName`. 
 
-Offering this functionality makes sense, when you have Services like database, where user might want to access the database with a fat client to analyse problems. To offer this functionality in your Service Broker add a class named `HaProxyServiceImpl` to: `de.evoila.cf.broker.haproxy`, with the following contents:
+Offering this functionality makes sense, when you have Services like database, where user might want to access the database with a fat client to analyse problems. To offer this functionality in your Service Broker see the according section in the configuration pages of this documentation.
 
-```java
-@Service
-@ConditionalOnBean(HAProxyConfiguration.class)
-public class HAProxyServiceImpl extends HAProxyService {
+Having defined this property, the Service Key functionality should be autowired and configured automatically. It reuses the `bind-service` functionality of the Service Broker to create Service Keys.
 
-	@Override
-	public Mode getMode(ServerAddress serverAddress) {
-		return Mode.TCP;
-	}
-	
-	@Override
-	public List<String> getOptions(ServerAddress serverAddress) {
-		return new ArrayList<>();
-	}
-}
-```
-
-Having defined this class, the Service Key functionality should be autowired and configured automatically. It reuses the `bind-service` functionality of the Service Broker to create Service Keys.
-
-*Note: to enable Service Keys via Service Broker Dashboard in UI see Dashboard section and configure `serviceKeys: true` in the module definition.*
-
-```js
-sharedModules: {
-  general: true,
-  backup: false,
-  serviceKeys: true // This needs to be set to truw
-}
-```
-
+Be aware, that the Service Broker does not change the underlying network architecture to realize external access to use the created Service Key, therefore you have to have access to the infrastructure, where the broker deploys its Service Instances. One way to do this is using `cf ssh` for an Application and access the Service Instance from there.
 
 ---
 


### PR DESCRIPTION
This PR contains a soft removal of the service keys documentation. "Soft" revers to the editing of the page for service keys instead of the complete removal. This way readers and customers can find a page explaining / stating the state of service keys instead of not finding anything and left guessing.